### PR TITLE
Plexbmc sections

### DIFF
--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -697,6 +697,12 @@
             <onclick>Skin.ToggleSetting(plexbmc)</onclick>
             <onclick>XBMC.ReloadSkin()</onclick>
           </item>
+          <item id="57" description="Refresh PleXBMC">
+            <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+            <visible>Container(300).HasFocus(10)</visible>
+            <label>Refresh</label>
+            <onclick>XBMC.RunScript(plugin.video.plexbmc,cacherefresh)</onclick>
+          </item>		  
         </content>
       </control>
     </control>


### PR DESCRIPTION
Hi,

Two small changes:
1. added a "nocat" option to the skin runscript.  This tells plexbmc to only display a single "shared..." entry for all section types.  Previously is created one per type (movies, tv,music,pictures) - which meant 4 "shared..." entries on the home page.  You only get this with myplex setup and the "shared" link option turned on.
2. Added a refresh entry to settings - so that cached data can be flushed and recreated.
