### PR TITLE
ADD: [plexbmc] section submenus

### DIFF
--- a/1080i/Home.xml
+++ b/1080i/Home.xml
@@ -128,6 +128,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.0.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.0.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.0.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.0.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.0.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.0.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.0.shared)]</property>
           </item>
           <item id="31">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.1.title))</visible>
@@ -137,6 +141,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.1.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.1.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.1.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.1.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.1.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.1.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.1.shared)]</property>
           </item>
           <item id="32">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.2.title))</visible>
@@ -146,6 +154,10 @@
             <onclick>$INFO[Window(Home).Property(plexbmc.2.path)]</onclick>
             <property name="type">$INFO[Window(Home).Property(plexbmc.2.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.2.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.2.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.2.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.2.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.2.shared)]</property>
           </item>
           <item id="33">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.3.title))</visible>
@@ -155,6 +167,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.3.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.3.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.3.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.3.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.3.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.3.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.3.shared)]</property>
           </item>
           <item id="34">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.4.title))</visible>
@@ -164,6 +180,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.4.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.4.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.4.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.4.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.4.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.4.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.4.shared)]</property>
           </item>
           <item id="35">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.5.title))</visible>
@@ -173,6 +193,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.5.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.5.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.5.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.5.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.5.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.5.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.5.shared)]</property>
           </item>
           <item id="36">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.6.title))</visible>
@@ -182,6 +206,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.6.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.6.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.6.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.6.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.6.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.6.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.6.shared)]</property>
           </item>
           <item id="37">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.7.title))</visible>
@@ -191,6 +219,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.7.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.7.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.7.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.7.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.7.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.7.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.7.shared)]</property>
           </item>
           <item id="39">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.8.title))</visible>
@@ -200,6 +232,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.8.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.8.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.8.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.8.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.8.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.8.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.8.shared)]</property>
           </item>
           <item id="40">
             <visible>Skin.HasSetting(plexbmc) + !IsEmpty(Window(Home).Property(plexbmc.9.title))</visible>
@@ -209,6 +245,10 @@
             <thumb>$INFO[Window(Home).Property(plexbmc.9.art)]</thumb>
             <property name="type">$INFO[Window(Home).Property(plexbmc.9.type)]</property>
             <property name="partial">$INFO[Window(Home).Property(plexbmc.9.partialpath)]</property>
+            <property name="search">$INFO[Window(Home).Property(plexbmc.9.search)]</property>
+            <property name="recent">$INFO[Window(Home).Property(plexbmc.9.recent)]</property>
+            <property name="viewed">$INFO[Window(Home).Property(plexbmc.9.viewed)]</property>
+            <property name="shared">$INFO[Window(Home).Property(plexbmc.9.shared)]</property>
           </item>
           <item id="50" description="Channels">
             <visible>Skin.HasSetting(plexbmc)</visible>
@@ -697,6 +737,27 @@
             <onclick>Skin.ToggleSetting(plexbmc)</onclick>
             <onclick>XBMC.ReloadSkin()</onclick>
           </item>
+          <item id="57" description="PleXBMC: recently added">
+            <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+            <visible>Container(300).HasFocus(30) | Container(300).HasFocus(31) | Container(300).HasFocus(32) | Container(300).HasFocus(33) | Container(300).HasFocus(34) | Container(300).HasFocus(35) | Container(300).HasFocus(36) | Container(300).HasFocus(37) | Container(300).HasFocus(38) | Container(300).HasFocus(39) | Container(300).HasFocus(40) </visible>
+            <visible>substring(Container(300).ListItem.Property(shared),false)</visible>
+            <label>Recently Added</label>
+            <onclick>$INFO[Container(300).ListItem.Property(recent)]</onclick>
+          </item>
+          <item id="58" description="PleXBMC: search">
+            <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+            <visible>Container(300).HasFocus(30) | Container(300).HasFocus(31) | Container(300).HasFocus(32) | Container(300).HasFocus(33) | Container(300).HasFocus(34) | Container(300).HasFocus(35) | Container(300).HasFocus(36) | Container(300).HasFocus(37) | Container(300).HasFocus(38) | Container(300).HasFocus(39) | Container(300).HasFocus(40) </visible>
+            <visible>substring(Container(300).ListItem.Property(shared),false)</visible>
+            <label>Search</label>
+            <onclick>$INFO[Container(300).ListItem.Property(search)]</onclick>
+          </item>
+          <item id="57" description="PleXBMC: Recently viewed">
+            <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+            <visible>Container(300).HasFocus(30) | Container(300).HasFocus(31) | Container(300).HasFocus(32) | Container(300).HasFocus(33) | Container(300).HasFocus(34) | Container(300).HasFocus(35) | Container(300).HasFocus(36) | Container(300).HasFocus(37) | Container(300).HasFocus(38) | Container(300).HasFocus(39) | Container(300).HasFocus(40) </visible>
+            <visible>substring(Container(300).ListItem.Property(shared),false)</visible>
+            <label>Recently Viewed</label>
+            <onclick>$INFO[Container(300).ListItem.Property(viewed)]</onclick>
+          </item>		  
         </content>
       </control>
     </control>

--- a/addon.xml
+++ b/addon.xml
@@ -6,7 +6,7 @@
   <extension
     point="xbmc.gui.skin"
     defaultthemename="Textures.xbt"
-    debugging="false">
+    debugging="true">
     <res width="1920" height="1080" aspect="16:9" default="true" folder="1080i" />
   </extension>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
This change adds some submenus in for plex sections, so they start to act a little more like the XBMC menus.  Only added three types,which I think is enough.  

Requires latest PleXBMC (currently 3.2.1 when I get round to releasing it).

Not sure how far you want me to go with changes, but I'll just try to add in similar functions to the XBMC side of Amber.  To be honest, I'm not sure there is anything left to modify.
