### PR TITLE
Add scaling to FS dimensions to fix aspect ratio

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -132,6 +132,7 @@
     <posy>0</posy>
     <width>1920</width>
     <height>1080</height>
+    <aspectratio>scale</aspectratio>
   </include>
   <include name="Panel_Size">
     <posx>36</posx>


### PR DESCRIPTION
Dimensions_Fullscreen (home BGs) is not scaled
BG.Defaults (settings BGs) is scaled
resulted in the background stretching by 2 pixels when going from
settings home screen to settings menu
(not major but slightly annoying for me)
