### PR TITLE
subtitle plugins doesn't send full path, but only short lang (ISO_639_1)

### DIFF
--- a/1080i/DialogSubtitles.xml
+++ b/1080i/DialogSubtitles.xml
@@ -113,7 +113,7 @@
             <width>33</width>
             <height>54</height>
             <aspectratio>keep</aspectratio>
-            <info>Listitem.Thumb</info>
+            <info>flags/$INFO[Listitem.Thumb].gif</info>
           </control>
           <control type="label">
             <posx>54</posx>


### PR DESCRIPTION
new subtitles addons doesn't send path (eg. flags/cs.gif) but only short lang (cs).
Taken from https://github.com/xbmc/xbmc/blob/master/addons/skin.confluence/720p/DialogSubtitles.xml#L140
