### PR TITLE
Added Overlays in Live TV Recordings

### DIFF
--- a/1080i/View_PVR.xml
+++ b/1080i/View_PVR.xml
@@ -430,7 +430,7 @@
 		<top>14</top>
 		<width>33</width>
 		<height>33</height>
-		<texture>img/OverlayStripe.png</texture>
+		<texture>OverlayInProgress.png</texture>
 		<visible>ListItem.IsResumable</visible>
 	</control>
         </itemlayout>
@@ -490,7 +490,7 @@
 		<top>14</top>
 		<width>33</width>
 		<height>33</height>
-		<texture>img/OverlayStripe.png</texture>
+		<texture>OverlayInProgress.png</texture>
 		<visible>ListItem.IsResumable</visible>
 	</control>
         </focusedlayout>


### PR DESCRIPTION
Hi

I have added overlay icons to the Live TV recordings section. The change is a bit sloppy and doesn't line up exactly with the TV/Movies section, but does get the job done :) 
