### PR TITLE
fixed CodecInfo screen with enabled PVR

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -34,7 +34,7 @@
     <font>
       <name>SysInfo</name>
       <filename>UbuntuCondensed.ttf</filename>
-      <size>28</size>
+      <size>24</size>
     </font>
     <font>
       <name>ExtProgressBar</name>

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -119,7 +119,7 @@
       <control type="image" description="Info Background">
         <visible>VideoPlayer.Content(LiveTV)</visible>
         <posx>0</posx>
-        <posy>165</posy>
+        <posy>210</posy>
         <width>1920</width>
         <height>177</height>
         <texture>img/BlackDotST2.png</texture>
@@ -158,7 +158,7 @@
 		<wrapmultiline>true</wrapmultiline>
       </control>
       <control type="group">
-        <posy>114</posy>
+        <posy>145</posy>
         <visible>VideoPlayer.Content(LiveTV)</visible>
         <control type="label" description="Backend">
           <posx>40</posx>


### PR DESCRIPTION
(prior that the transparent background were overlapping and text too)
