### PR TITLE
Fixed DialogOk.xml -> DialogOK.xml typo.

### DIFF
--- a/1080i/Custom_Debug.xml
+++ b/1080i/Custom_Debug.xml
@@ -651,8 +651,8 @@
         <shadowcolor>FF000000</shadowcolor>
         <font>SysInfo</font>
         <align>left</align>
-        <label>DialogOk.xml</label>
-        <visible>Window.IsVisible(DialogOk.xml)</visible>
+        <label>DialogOK.xml</label>
+        <visible>Window.IsVisible(DialogOK.xml)</visible>
       </control>
       <control type="label">
         <width>1170</width>


### PR DESCRIPTION
Currently getting errors like "could not find DialogOk.xml" file; I'm assuming this is because the string in Custom_Debug.xml is wrong (correct would be DialogOK.xml, with capital **K**)
