### PR TITLE
Add flagging for stereoscopic (3D) videos.

### DIFF
--- a/1080i/DialogFullScreenInfo.xml
+++ b/1080i/DialogFullScreenInfo.xml
@@ -62,6 +62,18 @@
               <texturefocus>badges/video/ResFrame.png</texturefocus>
               <label>$INFO[VideoPlayer.VideoResolution]</label>
             </control>
+            <control type="button">
+              <visible>VideoPlayer.IsStereoscopic</visible>
+              <height>36</height>
+              <width>102</width>
+              <font>Flags</font>
+              <align>center</align>
+              <textoffsetx>0</textoffsetx>
+              <colordiffuse>Silver</colordiffuse>
+              <texturenofocus>badges/video/ResFrame.png</texturenofocus>
+              <texturefocus>badges/video/ResFrame.png</texturefocus>
+              <label>3D</label>
+            </control>
             <control type="image">
               <visible>!IsEmpty(VideoPlayer.VideoCodec)</visible>
               <height>36</height>

--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -401,6 +401,18 @@
             <texturefocus>badges/video/ResFrame.png</texturefocus>
             <label>$INFO[ListItem.VideoResolution]</label>
           </control>
+          <control type="button">
+            <visible>ListItem.IsStereoscopic</visible>
+            <height>36</height>
+            <width>102</width>
+            <font>Flags</font>
+            <align>center</align>
+            <textoffsetx>0</textoffsetx>
+            <colordiffuse>Silver</colordiffuse>
+            <texturenofocus>badges/video/ResFrame.png</texturenofocus>
+            <texturefocus>badges/video/ResFrame.png</texturefocus>
+            <label>3D</label>
+          </control>
           <control type="image">
             <visible>!IsEmpty(ListItem.VideoCodec)</visible>
             <height>36</height>

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -1626,6 +1626,15 @@
         <colordiffuse>Silver</colordiffuse>
         <texture>$INFO[ListItem.VideoResolution,badges/video/,.png]</texture>
       </control>
+      <control type="image">
+        <visible>ListItem.IsStereoscopic</visible>
+        <height>45</height>
+        <width>90</width>
+        <bordersize>3</bordersize>
+        <aspectratio>keep</aspectratio>
+        <colordiffuse>Silver</colordiffuse>
+        <texture>badges/video/3d.png</texture>
+      </control>
     </control>
   </include>
 </includes>

--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -66,6 +66,18 @@
                 <texturefocus>badges/video/ResFrame.png</texturefocus>
                 <label>$INFO[VideoPlayer.VideoResolution]</label>
               </control>
+              <control type="button">
+                <visible>VideoPlayer.IsStereoscopic</visible>
+                <height>36</height>
+                <width>102</width>
+                <font>Flags</font>
+                <align>center</align>
+                <textoffsetx>0</textoffsetx>
+                <colordiffuse>Silver</colordiffuse>
+                <texturenofocus>badges/video/ResFrame.png</texturenofocus>
+                <texturefocus>badges/video/ResFrame.png</texturefocus>
+                <label>3D</label>
+              </control>
               <control type="image">
                 <visible>!IsEmpty(VideoPlayer.VideoCodec)</visible>
                 <height>36</height>

--- a/1080i/View_57_58_59_Showcase.xml
+++ b/1080i/View_57_58_59_Showcase.xml
@@ -71,6 +71,15 @@
         <texture>$INFO[ListItem.VideoResolution,badges/video/,.png]</texture>
       </control>
       <control type="image">
+        <visible>ListItem.IsStereoscopic</visible>
+        <height>45</height>
+        <width>90</width>
+        <bordersize>3</bordersize>
+        <aspectratio>keep</aspectratio>
+        <colordiffuse>Silver</colordiffuse>
+        <texture>badges/video/3d.png</texture>
+      </control>
+      <control type="image">
         <visible>container.content(albums) | container.content(songs)</visible>
         <height>45</height>
         <width>174</width>


### PR DESCRIPTION
Not sure if wanted, however... I'd like to know if a video is 3D.
Tested in all views, both movies and episodes.

**Don't merge as is yet** because this is only the XML part... I'm not really in graphics and this needs an icon from you (or someone else...).  The icon is expected to be located in badges/video/3d.png. DialogVideoInfo, instead, uses the same trick you're using for video resolution, to be consistent.

Edit: updated as I was missing DialogFullScreenInfo. Also added to VideoFullScreen, although for some reason that block is commented out.