### PR TITLE
Dialog Seek Bar shows how much a video is buffered

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -48,8 +48,9 @@
           <height>18</height>
           <texturebg border="15,0,15,0">VideoOSD/ProgressBG.png</texturebg>
           <midtexture border="15,0,15,0">VideoOSD/ProgressBar.png</midtexture>
-          <info>Player.CacheLevel</info>
-          <visible>Player.Caching</visible>
+          <colordiffuse>Diffuse2</colordiffuse>
+          <info>Player.ProgressCache</info>
+          <visible>true</visible>
         </control>
         <control type="progress" id="23" description="Progress Bar">
           <posx>600</posx>


### PR DESCRIPTION
Based on the default skin of Kodi, I updated Amber skin to make that the seekbar shows how much a video is buffered in osd menu. In the screenshoots, the buffer bar is in a grey color behind the yellow bar.

![screenshot001](https://cloud.githubusercontent.com/assets/330441/6314020/5ca89ece-b9ca-11e4-9c0b-ed7e33ae272a.png)
![screenshot002](https://cloud.githubusercontent.com/assets/330441/6314021/5cf5dffe-b9ca-11e4-984d-c9da517755c7.png)
