### PR TITLE
Updated German translation and exit behaviour in EPG-Timeline

### DIFF
--- a/1080i/View_PVR.xml
+++ b/1080i/View_PVR.xml
@@ -646,7 +646,8 @@
 				<onright>101</onright>
 				<onup>10</onup>
 				<ondown>10</ondown>
-				<onback>101</onback>
+				<!-- commented out the next line below so it is possible to exit Timeline with backspace -->
+				<!-- <onback>101</onback> -->
 				<rulerlayout height="80" width="60">
 					<control type="image" id="1" description="Header row">
 						<width>60</width>

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -226,11 +226,11 @@ msgstr "Verfügbare[CR]Gruppen"
 
 msgctxt "#31507"
 msgid "Movies homescreen button opens:"
-msgstr "Filme im Hauptmenü öffnet:"
+msgstr "\"Filme\" im Hauptmenü öffnet:"
 
 msgctxt "#31508"
 msgid "TV Shows homescreen button opens:"
-msgstr "TV Serien im Hauptmenü öffnet:"
+msgstr "\"Serien\" im Hauptmenü öffnet:"
 
 msgctxt "#31510"
 msgid "Timer Set"
@@ -422,7 +422,7 @@ msgstr "Home-Layout"
 
 msgctxt "#31996"
 msgid "Holiday snowfall theme"
-msgstr "Winterlicher Schneefall"
+msgstr "\"Winter / Schnefall\" Animation"
 
 msgctxt "#31997"
 msgid "Hide channel logos in PVR List/Timeline"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -46,15 +46,15 @@ msgstr "Geteilt"
 
 msgctxt "#31007"
 msgid "PleKodi settings"
-msgstr "PleKodi-Einstellungen"
+msgstr "Plex AddOn Einstellungen"
 
 msgctxt "#31008"
 msgid "Go Plex"
-msgstr "Plex"
+msgstr "Zeige Plex-Bibliothek"
 
 msgctxt "#31009"
 msgid "Go Kodi"
-msgstr "Kodi"
+msgstr "Zeige Kodi-Bibliothek"
 
 msgctxt "#31010"
 msgid "Queue"
@@ -62,7 +62,7 @@ msgstr "Abspielliste"
 
 msgctxt "#31011"
 msgid "Recently Viewed"
-msgstr "Zuletzt angeschaut"
+msgstr "Zuletzt gesehen"
 
 msgctxt "#31012"
 msgid "Recently Released"
@@ -74,7 +74,7 @@ msgstr "Zuletzt ausgestrahlt"
 
 msgctxt "#31014"
 msgid "On Deck"
-msgstr "Im Deck"
+msgstr "Aktuell"
 
 msgctxt "#31020"
 msgid "Recently Added"
@@ -98,7 +98,7 @@ msgstr "Einstellungslevel"
 
 msgctxt "#31110"
 msgid "Edit Background for Media Type"
-msgstr "Hintergrund für Menüpunkt ändern"
+msgstr "Hintergrund für den Menüpunkt ändern"
 
 msgctxt "#31113"
 msgid "Single Image"
@@ -114,7 +114,7 @@ msgstr "Musik-Wiedergabeliste starten, wenn Kodi gestartet wird"
 
 msgctxt "#31116"
 msgid "Startup playlist"
-msgstr "Einschalt-Wiedergabeliste"
+msgstr "Autostart-Wiedergabeliste"
 
 msgctxt "#31132"
 msgid "Lyrics Add-on"
@@ -226,11 +226,11 @@ msgstr "Verfügbare[CR]Gruppen"
 
 msgctxt "#31507"
 msgid "Movies homescreen button opens:"
-msgstr "Home-Screen-Knopf für Filme öffnet:"
+msgstr "Filme im Hauptmenü öffnet:"
 
 msgctxt "#31508"
 msgid "TV Shows homescreen button opens:"
-msgstr "TV Serien Hauptmenüknopf öffnet:"
+msgstr "TV Serien im Hauptmenü öffnet:"
 
 msgctxt "#31510"
 msgid "Timer Set"
@@ -238,19 +238,19 @@ msgstr "Timer gesetzt"
 
 msgctxt "#31901"
 msgid "36 Hour Forecast"
-msgstr "36 Stunden-Prognose"
+msgstr "36 Stunden Vorhersage"
 
 msgctxt "#31902"
 msgid "Hourly Forecast"
-msgstr "Stündliche Prognose"
+msgstr "Stündliche Vorhersage"
 
 msgctxt "#31903"
 msgid "Weekend Forecast"
-msgstr "Wochenendprognose"
+msgstr "Wöchentliche Vorhersage"
 
 msgctxt "#31904"
 msgid "10 Day Forecast"
-msgstr "10 Tage-Prognose"
+msgstr "10 Tage Vorhersage"
 
 msgctxt "#31954"
 msgid "S"
@@ -266,7 +266,7 @@ msgstr "Lade Theme"
 
 msgctxt "#31957"
 msgid "Hide Update library button from home submenu"
-msgstr "Bibliothek aktualisieren-Schaltfläche im Hauptuntermenü verbergen"
+msgstr "\"Bibliothek aktualisieren\" im Hauptuntermenü verbergen"
 
 msgctxt "#31958"
 msgid "Big Panel"
@@ -282,15 +282,15 @@ msgstr "Musik öffnet Künstler"
 
 msgctxt "#31961"
 msgid "Recently added"
-msgstr "Zuletzt hinzugefügte Konzerte"
+msgstr "Zuletzt hinzugefügt"
 
 msgctxt "#31962"
 msgid "Low List"
-msgstr "Empfohlene Konzerte"
+msgstr "Liste (niedrig)"
 
 msgctxt "#31963"
 msgid "Panel"
-msgstr "Empfohlene Alben"
+msgstr "Panel"
 
 msgctxt "#31964"
 msgid "Configure shelf items"
@@ -298,11 +298,11 @@ msgstr "Shelf-Inhalt konfigurieren"
 
 msgctxt "#31965"
 msgid "Banner List"
-msgstr "Empfohlene Folge"
+msgstr "Banner Liste"
 
 msgctxt "#31966"
 msgid "Recommended"
-msgstr "Empfohlene Filme"
+msgstr "Empfohlen"
 
 msgctxt "#31967"
 msgid "Enable Home shelf"
@@ -354,7 +354,7 @@ msgstr "Statistik im Homebildschirm anzeigen"
 
 msgctxt "#31979"
 msgid "Loading..."
-msgstr "Arbeitet..."
+msgstr "Bitte warten..."
 
 msgctxt "#31980"
 msgid "Hide unwatched and partialy watched marks"


### PR DESCRIPTION
I've made some changes to the German translation, so they now should be correct.
I also made a small change (commented out 1 line) to the "EPG Timeline" view, so it is closed on hitting the "Back-Key" which is then a consistent behaviour in all Live-TV Windows like TV Channels, Radio Channels, Recordings and so on.