### PR TITLE
Player video on menu screens & inconsistant background fixes

### DIFF
--- a/1080i/CustomAddons.xml
+++ b/1080i/CustomAddons.xml
@@ -4,7 +4,14 @@
   <include>OpenClose</include>
   <controls>
     <control type="group" description="fanart">
-      <include>Fanart_Art</include>
+	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <control type="image" description="fa overlay">
       <visible>Control.IsVisible(50)</visible>

--- a/1080i/CustomAddons.xml
+++ b/1080i/CustomAddons.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window id="1119">
+<window id="1119" description="add-ons">
   <defaultcontrol always="true">50</defaultcontrol>
-  <include>OpenClose</include>
+  <include>VignetteFade</include>
   <controls>
-    <control type="group" description="fanart">
-	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+    <control type="group" description="background">
+	  <control type="multiimage" description="FA fullscreen">
+        <visible>Control.IsVisible(50)</visible>
+        <include>BG.Defaults</include>
+        <imagepath background="true" fallback="special://skin/backgrounds/Addons.jpg">$INFO[Skin.String(Addons.Background)]</imagepath>
+      </control>
 	  <control type="videowindow">
 	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
 	    <posx>0</posx>

--- a/1080i/DialogFavourites.xml
+++ b/1080i/DialogFavourites.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window type="window">
   <defaultcontrol always="true">450</defaultcontrol>
+  <include>VignetteFade</include>
   <controls>
-    <control type="image" description="BG">
-      <posx>0</posx>
-      <posy>0</posy>
-      <width>1920</width>
-      <height>1080</height>
-      <texture>img/BlackDot.png</texture>
+	<control type="multiimage" description="FA fullscreen">
+      <visible>Control.IsVisible(450)</visible>
+      <include>BG.Defaults</include>
+      <imagepath background="true" fallback="special://skin/backgrounds/Favourites.jpg">$INFO[Skin.String(Favourites.Background)]</imagepath>
+    </control>
+	<control type="group" description="BG">
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <control type="group">
-      <include>OpenClose</include>
       <control type="image">
         <posx>0</posx>
         <posy>0</posy>
@@ -39,7 +46,7 @@
       </control>
     </control>
     <control type="group" description="Grid view">
-      <include>OpenClose</include>
+      <include>ContentFade</include>
       <control type="panel" id="450" description="Grid">
         <posx>60</posx>
         <posy>90</posy>

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -48,8 +48,9 @@
           <height>18</height>
           <texturebg border="15,0,15,0">VideoOSD/ProgressBG.png</texturebg>
           <midtexture border="15,0,15,0">VideoOSD/ProgressBar.png</midtexture>
-          <info>Player.CacheLevel</info>
-          <visible>Player.Caching</visible>
+          <colordiffuse>Diffuse2</colordiffuse>
+          <info>Player.ProgressCache</info>
+          <visible>true</visible>
         </control>
         <control type="progress" id="23" description="Progress Bar">
           <posx>600</posx>

--- a/1080i/MyMusicNav.xml
+++ b/1080i/MyMusicNav.xml
@@ -5,7 +5,14 @@
   <onunload>ClearProperty(gallery)</onunload>
   <controls>
     <control type="group" description="fanart">
-	  <include>Fanart_Art</include>
+	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <include>View_50</include>
     <include>View_51_Panel_Music</include>

--- a/1080i/MyMusicSongs.xml
+++ b/1080i/MyMusicSongs.xml
@@ -4,7 +4,14 @@
   <include>OpenClose</include>
   <controls>
     <control type="group" description="fanart">
-      <include>Fanart_Art</include>
+      <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <include>View_50</include>
     <include>View_51_Panel_Music</include>

--- a/1080i/MyPVR.xml
+++ b/1080i/MyPVR.xml
@@ -4,7 +4,14 @@
   <allowoverlay>no</allowoverlay>
   <controls>
     <control type="group" description="fanart">
-      <include>Pvr_Art</include>
+	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Pvr_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
         <control type="image" description="fa overlay">
 	  <visible>Control.IsVisible(10) | Control.IsVisible(11) | Control.IsVisible(12)</visible>

--- a/1080i/MyPics.xml
+++ b/1080i/MyPics.xml
@@ -3,7 +3,14 @@
   <defaultcontrol always="true">50</defaultcontrol>
   <controls>
     <control type="group" description="fanart">
-      <include>Pictures_Art</include>
+	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Pictures_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <include>View_50</include>
     <include>View_51_Panel_Music</include>

--- a/1080i/MyPrograms.xml
+++ b/1080i/MyPrograms.xml
@@ -3,7 +3,14 @@
   <defaultcontrol always="true">50</defaultcontrol>
   <controls>
     <control type="group" description="fanart">
-      <include>Fanart_Art</include>
+	  <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
     <include>View_50</include>
     <include>View_51_Panel_Music</include>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -6,7 +6,14 @@
   <onunload>ClearProperty(gallery)</onunload>
   <controls>
     <control type="group" description="BG">
-      <include>Fanart_Art</include>
+      <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Fanart_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     </control>
 	<include>View_50</include>
     <include>View_51_Panel</include>

--- a/1080i/MyWeather.xml
+++ b/1080i/MyWeather.xml
@@ -3,7 +3,14 @@
   <defaultcontrol always="true">50</defaultcontrol>
   <animation delay="600" effect="fade" time="250">WindowClose</animation>
   <controls>
-    <include>Weather_Art</include>
+    <include condition="![Player.HasVideo + Skin.HasSetting(Show_Player)] + !Skin.HasSetting(Home_DefaultBG)">Weather_Art</include>
+	  <control type="videowindow">
+	    <visible>Player.HasVideo + Skin.HasSetting(Show_Player)</visible>
+	    <posx>0</posx>
+	    <posy>0</posy>
+        <width>1920</width>
+        <height>1080</height>
+	  </control>
     <include>Time</include>
     <control type="button" id="50">
       <include>HiddenButton</include>

--- a/addon.xml
+++ b/addon.xml
@@ -5,8 +5,7 @@
     <import addon="script.favourites" version="3.2.0"/>
     <import addon="service.skin.widgets" version="0.0.27"/>
   </requires>
-  <extension
-    point="xbmc.gui.skin" defaultthemename="Textures.xbt" debugging="false">
+  <extension point="xbmc.gui.skin" debugging="false">
     <res width="1920" height="1080" aspect="16:9" default="true" folder="1080i" />
   </extension>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
3846dbb &  91f468e  (Video menus):
This is a modification i have been using since early frodo.  It simply extends the video as background on home screen to all menus.  Creates a more seamless menu overlay effect.

286c16e:
This mod implements the add-on background when navigating menus and adds the favorites background or player video as background.

I have also incorporated pull request #78 & #76 and both work well.  #78 fixes the install (missing files) issue.



