### PR TITLE
Add plexhome menu items

### DIFF
--- a/1080i/Includes_Plexbmc.xml
+++ b/1080i/Includes_Plexbmc.xml
@@ -3062,7 +3062,7 @@
       <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
       <visible>Container(300).HasFocus(10)</visible>
       <label>$LOCALIZE[31017]</label>
-      <onclick>XBMC.RunScript(plugin.video.plexbmc,cacherefresh)</onclick>
+      <onclick>XBMC.RunScript(plugin.video.plexbmc,switchuser)</onclick>
       <visible>substring(Window(Home).Property(plexbmc.plexhome_enabled),true)</visible>
     </item>
     <item id="58" description="PleXBMC: search">

--- a/1080i/Includes_Plexbmc.xml
+++ b/1080i/Includes_Plexbmc.xml
@@ -3018,6 +3018,20 @@
       <onclick condition="!Library.HasContent(music)">ActivateWindow(MusicFiles,"plugin://plugin.video.plexbmc/?url=http://music&amp;mode=22",return)</onclick>
       <onclick condition="Library.HasContent(music)">ActivateWindow(MusicLibrary,"plugin://plugin.video.plexbmc/?url=http://music&amp;mode=22",return)</onclick>
     </item>
+    <item id="66" description="PleXBMC: Sign in">
+      <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+      <visible>Container(300).HasFocus(10)</visible>
+      <label>$LOCALIZE[31015]</label>
+      <onclick>XBMC.RunScript(plugin.video.plexbmc,signin)</onclick>
+      <visible>substring(Window(Home).Property(plexbmc.myplex_signedin),false)</visible>
+    </item>
+    <item id="67" description="PleXBMC: Sign Out">
+      <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+      <visible>Container(300).HasFocus(10)</visible>
+      <label>$LOCALIZE[31016]</label>
+      <onclick>XBMC.RunScript(plugin.video.plexbmc,signout)</onclick>
+      <visible>substring(Window(Home).Property(plexbmc.myplex_signedin),true)</visible>
+    </item>
     <item id="54" description="PleXBMC Settings">
       <visible>System.HasAddon(plugin.video.plexbmc)</visible>
       <visible>Container(300).HasFocus(10)</visible>
@@ -3043,6 +3057,13 @@
       <visible>Container(300).HasFocus(10)</visible>
       <label>$LOCALIZE[184]</label>
       <onclick>XBMC.RunScript(plugin.video.plexbmc,cacherefresh)</onclick>
+    </item>
+    <item id="68" description="PleXBMC: Switch User">
+      <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>
+      <visible>Container(300).HasFocus(10)</visible>
+      <label>$LOCALIZE[31017]</label>
+      <onclick>XBMC.RunScript(plugin.video.plexbmc,cacherefresh)</onclick>
+      <visible>substring(Window(Home).Property(plexbmc.plexhome_enabled),true)</visible>
     </item>
     <item id="58" description="PleXBMC: search">
       <visible>System.HasAddon(plugin.video.plexbmc) + Skin.HasSetting(plexbmc)</visible>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -76,7 +76,19 @@ msgctxt "#31014"
 msgid "On Deck"
 msgstr ""
 
-#empty strings from id 31015 to 31019
+msgctxt "#31015"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#31016"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#31017"
+msgid "Switch User"
+msgstr ""
+
+#empty strings from id 31018 to 31019
 
 msgctxt "#31020"
 msgid "Recently Added"


### PR DESCRIPTION
Hi

Firstly, sorry for being really poor on getting back to your emails.  

Next, I've made a few slight additions to incorporate plexhome functions on the settings popout menu.  These have been added to the newest version of plexbmc (4.0.0~beta1) along with a number of rewrites.  This change adds:

1. Sign In - visible only if you haven;t already signed in
2. Switch user - visible only if plexhome is enabled on your server
3. Sign out - visible only when you are signed in.

None of these should affect either non-plexbmc users, or users on older plexbmc version (< 4) - the items simply don't show up.

Any chance of adding?